### PR TITLE
Add iam_builder to list of mojap packages

### DIFF
--- a/mojap_package_names.py
+++ b/mojap_package_names.py
@@ -23,7 +23,8 @@ mojap_packages = [
     ("s3-data-packer", "s3_data_packer"),
     ("arrow-pd-parser", "mojap-arrow-pd-parser"),
     ("gluejobutils", "gluejobutils"),
-    ("dataengineeringutils3", "dataengineeringutils3")
+    ("dataengineeringutils3", "dataengineeringutils3"),
+    ("iam-builder", "iam_builder")
 ]
 
 packages_to_install = [p[0] for p in mojap_packages if p[1] != repo_name]


### PR DESCRIPTION
Add `iam_builder` to list of mojap packages due to `data-linter`'s dependency on it.